### PR TITLE
chore: SQL テストハーネス導入 + 例テスト追加

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+TEST_DIR="$ROOT_DIR/tests"
+OUT_DIR="$TEST_DIR/out"
+EXP_DIR="$TEST_DIR/expected"
+SCHEMA="$ROOT_DIR/schema.sql"
+
+mkdir -p "$OUT_DIR"
+
+green() { printf "\033[32m%s\033[0m\n" "$*"; }
+red()   { printf "\033[31m%s\033[0m\n" "$*"; }
+
+fail=0
+total=0
+
+for sql in "$TEST_DIR"/*.sql; do
+  [ -f "$sql" ] || continue
+  total=$((total+1))
+  name=$(basename "$sql" .sql)
+  db="$OUT_DIR/$name.db"
+  out="$OUT_DIR/$name.csv"
+  exp="$EXP_DIR/$name.csv"
+
+  rm -f "$db" "$out"
+  sqlite3 "$db" < "$SCHEMA"
+  # Run test SQL and capture CSV with headers
+  if ! sqlite3 -cmd ".headers on" -cmd ".mode csv" "$db" < "$sql" > "$out"; then
+    red "ERROR running $name.sql"
+    fail=$((fail+1))
+    continue
+  fi
+  # Normalize line endings (strip CR)
+  tmp="$out.tmp"
+  tr -d '\r' < "$out" > "$tmp" && mv "$tmp" "$out"
+  if ! diff -u "$exp" "$out"; then
+    red "FAIL: $name"
+    fail=$((fail+1))
+  else
+    green "PASS: $name"
+  fi
+done
+
+echo "-----"
+echo "Total: $total, Failed: $fail"
+exit $fail

--- a/tests/expected/valuation_basic.csv
+++ b/tests/expected/valuation_basic.csv
@@ -1,0 +1,2 @@
+date,ticker,ccy,qty,price_ccy,fx_rate,value_jpy_3dp
+2025-09-15,VTI,USD,2037.88,270.5,145.2,80040997.608

--- a/tests/valuation_basic.sql
+++ b/tests/valuation_basic.sql
@@ -1,0 +1,17 @@
+-- prepare data
+INSERT INTO assets (ticker, ccy) VALUES ('VTI','USD');
+INSERT INTO fx_rates (date, pair, rate) VALUES ('2025-09-15','USDJPY',145.2);
+INSERT INTO snapshots (date, ticker, qty, price_ccy) VALUES ('2025-09-15','VTI',2037.88,270.5);
+
+-- assert valuation (rounded for determinism)
+SELECT
+  date,
+  ticker,
+  ccy,
+  qty,
+  price_ccy,
+  fx_rate,
+  round(value_jpy, 3) AS value_jpy_3dp
+FROM v_valuation
+ORDER BY date, ticker;
+


### PR DESCRIPTION
## 概要
SQL ベースの軽量テストハーネスを導入し、ビュー/制約の変更をローカルで素早く検証できるようにします。

## 変更点
- `scripts/test.sh`
  - テストごとに `schema.sql` から SQLite DB を作成
  - `tests/*.sql` をヘッダー付きCSVで実行し、CRLF 正規化
  - 出力を `tests/out/*.csv` に保存し、`tests/expected/*.csv` と `diff` 比較
  - サマリ表示/失敗時は非ゼロ終了
- サンプルテスト
  - `tests/valuation_basic.sql` + `tests/expected/valuation_basic.csv`
  - `v_valuation` の結果を丸めてゴールデン化

## 背景/目的
- 外部ツール不要で素早いフィードバックループを確立
- 原因分解のゴールデンテスト（#7）を追加する足場を用意

## 使い方/確認方法
```bash
./scripts/test.sh
```
期待: 例テストが PASS し、失敗時は差分が表示されます。

## 関連Issue
Fixes #6

## チェックリスト
- [x] ハーネス追加
- [x] 評価額の基本テストを1件追加
- [ ] フォローアップ: 原因分解のケース追加（#7）
