### PR TITLE
feat: v_attribution 追加（価格/為替/クロス/フロー分解 + 日次合計）

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -55,3 +55,59 @@ SELECT
 FROM snapshots s
 JOIN assets a ON a.ticker = s.ticker
 LEFT JOIN fx_rates r ON r.date = s.date AND r.pair = (a.ccy || 'JPY');
+
+-- View: attribution of daily change into price, fx, cross, and flow
+DROP VIEW IF EXISTS v_attribution;
+CREATE VIEW v_attribution AS
+WITH base AS (
+  SELECT
+    s1.date AS date,
+    s1.ticker AS ticker,
+    a.ccy AS ccy,
+    s0.qty AS q0,
+    s1.qty AS q1,
+    s0.price_ccy AS p0,
+    s1.price_ccy AS p1,
+    CASE WHEN a.ccy = 'JPY' THEN 1.0 ELSE f0.rate END AS r0,
+    CASE WHEN a.ccy = 'JPY' THEN 1.0 ELSE f1.rate END AS r1,
+    -- Components per spec
+    (s1.qty - s0.qty) * (s1.price_ccy) * (CASE WHEN a.ccy='JPY' THEN 1.0 ELSE f1.rate END) AS flow,
+    (s0.qty) * (s1.price_ccy - s0.price_ccy) * (CASE WHEN a.ccy='JPY' THEN 1.0 ELSE f1.rate END) AS delta_price,
+    (s0.qty) * (s0.price_ccy) * ((CASE WHEN a.ccy='JPY' THEN 1.0 ELSE f1.rate END) - (CASE WHEN a.ccy='JPY' THEN 1.0 ELSE f0.rate END)) AS delta_fx,
+    (s0.qty) * (s1.price_ccy - s0.price_ccy) * ((CASE WHEN a.ccy='JPY' THEN 1.0 ELSE f1.rate END) - (CASE WHEN a.ccy='JPY' THEN 1.0 ELSE f0.rate END)) AS delta_cross
+  FROM snapshots s1
+  JOIN snapshots s0
+    ON s0.ticker = s1.ticker
+   AND s0.date = date(s1.date, '-1 day')
+  JOIN assets a ON a.ticker = s1.ticker
+  LEFT JOIN fx_rates f1
+    ON a.ccy <> 'JPY'
+   AND f1.date = s1.date
+   AND f1.pair = (a.ccy || 'JPY')
+  LEFT JOIN fx_rates f0
+    ON a.ccy <> 'JPY'
+   AND f0.date = s0.date
+   AND f0.pair = (a.ccy || 'JPY')
+  WHERE a.ccy = 'JPY' OR (f1.rate IS NOT NULL AND f0.rate IS NOT NULL)
+)
+SELECT
+  date,
+  ticker,
+  (q1*p1*r1 - q0*p0*r0)              AS delta_total,
+  delta_price,
+  delta_fx,
+  delta_cross,
+  flow
+FROM base
+UNION ALL
+SELECT
+  date,
+  'PORTFOLIO' AS ticker,
+  SUM(q1*p1*r1 - q0*p0*r0)           AS delta_total,
+  SUM(delta_price)                   AS delta_price,
+  SUM(delta_fx)                      AS delta_fx,
+  SUM(delta_cross)                   AS delta_cross,
+  SUM(flow)                          AS flow
+FROM base
+GROUP BY date
+;


### PR DESCRIPTION
## 概要
日次の評価額差分を「価格」「為替」「クロス」「フロー」に分解する `v_attribution` を追加します。銘柄行に加えて日次ポートフォリオ合計行も出力します。

## 変更点
- `schema.sql`
  - `v_attribution` 追加
  - 計算式:
    - Flow = (q1 - q0) × p1 × r1
    - Price = q0 × (p1 - p0) × r1
    - FX = q0 × p0 × (r1 - r0)
    - Cross = q0 × (p1 - p0) × (r1 - r0)
    - Total = q1 p1 r1 − q0 p0 r0 = Price + FX + Cross + Flow
  - JPY 資産は `r=1` 扱い、FX 要因は常に 0
  - 非 JPY 資産は当日/前日の為替が両方揃っている場合のみ出力（欠損は除外＝エラー検知）
  - 出力: `date, ticker, delta_total, delta_price, delta_fx, delta_cross, flow`
  - `PORTFOLIO` 行を日次で集計して併記

## 背景/目的
MVP の核となる原因分解をビューとして提供し、テスト（#7）や可視化の土台にします（定義は #12 にて合意済み）。

## 使い方/確認方法（簡易）
```sql
SELECT * FROM v_attribution WHERE date='YYYY-MM-DD' ORDER BY ticker;
```

## 関連Issue
Fixes #3

## ノート
- ゴールデンテストは別PR（#7）で追加します。
