### PR TITLE
docs: README をMVP仕様に同期（ビュー例とテスト手順を追記）

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,28 @@ INSERT INTO cashflows (date, ticker, type, amount_ccy, ccy)
   VALUES ('2025-09-15','VTI','DIVIDEND',200,'USD');
 
 
-	6.	ビューで確認
+	6.	評価額ビュー（円換算）
 
 SELECT * FROM v_valuation WHERE date='2025-09-15';
+
+
+	7.	原因分解ビュー（価格/為替/クロス/フロー）
+
+SELECT date, ticker,
+       round(delta_total,3) AS total,
+       round(delta_price,3) AS price,
+       round(delta_fx,3)    AS fx,
+       round(delta_cross,3) AS cross,
+       round(flow,3)        AS flow
+  FROM v_attribution
+ WHERE date='2025-09-15'
+ ORDER BY ticker;  -- 'PORTFOLIO' 行も併記
+
+
+	8.	テスト（開発者向け）
+
+./scripts/test.sh
+  # 例: valuation と attribution のゴールデンテストが PASS します
 
 
 
@@ -84,6 +103,6 @@ SELECT * FROM v_valuation WHERE date='2025-09-15';
 	•	完全に個人利用前提。クラウド共有や公開環境への配置は想定していません。
 	•	為替・株価データは外部 API や CSV インポートにより各自で取得してください。
 	•	個人情報や資産データはローカル保存を推奨します。
+	•	DB ファイル（money_diary.db）や `data/` は .gitignore 済み。Git に含めないでください。
 
 ⸻
-


### PR DESCRIPTION
## 概要
README の「使い方」を最新スキーマ/ビューに同期し、開発者向けテスト手順を追記します。

## 変更点
- `v_valuation`（円換算）と `v_attribution`（原因分解）のクエリ例を追加
- 初期化〜スナップショット入力〜ビュー確認までのコマンドを整理
- `./scripts/test.sh` の実行方法を追記
- .gitignore 方針（DB/`data/`）に注意書きを追加

## 背景/目的
初見でもコピペでMVPの流れを再現できるよう、手順の抜け漏れを解消。

## 使い方/確認方法
README の「🚀 使い方」を上から順に実行し、`v_valuation`/`v_attribution` の結果が得られることを確認。

## 関連Issue
Fixes #8
