### PR TITLE
chore: CSV I/O スクリプト追加（fx import / snapshots export）

### DIFF
--- a/scripts/export_snapshots.sh
+++ b/scripts/export_snapshots.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+使い方: $(basename "$0") [out_csv] [db_path]
+
+説明:
+  snapshots テーブルをヘッダー付きCSVでエクスポートします。
+
+引数:
+  out_csv : 出力CSVパス（省略可、既定: data/snapshots.csv）
+  db_path : SQLite DB パス（省略可、既定: money_diary.db）
+
+例:
+  $(basename "$0")
+  $(basename "$0") data/snapshots.csv money_diary.db
+USAGE
+}
+
+OUT=${1:-data/snapshots.csv}
+DB=${2:-money_diary.db}
+
+mkdir -p "$(dirname "$OUT")"
+sqlite3 -header -csv "$DB" "SELECT * FROM snapshots ORDER BY date, ticker" > "$OUT"
+echo "Exported snapshots to $OUT"
+

--- a/scripts/import_fx.sh
+++ b/scripts/import_fx.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+使い方: $(basename "$0") <csv_path> [db_path]
+
+説明:
+  fx_rates テーブルへ CSV をインポートします（ヘッダー1行を自動スキップ）。
+
+引数:
+  csv_path : 入力CSV（列: date,pair,rate）
+  db_path  : SQLite DB パス（省略可、既定: money_diary.db）
+
+例:
+  $(basename "$0") data/fx_rates.csv
+USAGE
+}
+
+CSV=${1:-}
+DB=${2:-money_diary.db}
+
+if [[ -z "${CSV}" || ! -f "${CSV}" ]]; then
+  usage; echo "ERROR: CSV ファイルを指定してください: $CSV" 1>&2; exit 1
+fi
+
+TMP=$(mktemp)
+# ヘッダーを除去
+tail -n +2 "$CSV" > "$TMP"
+
+sqlite3 "$DB" <<SQL
+.mode csv
+.import "$TMP" fx_rates
+SQL
+
+rm -f "$TMP"
+echo "Imported fx_rates from $CSV into $DB"
+


### PR DESCRIPTION
## 概要
CSV 入出力の最小スクリプトを追加し、ローカルでのデータ往復を簡便化します。

## 変更点
- `scripts/import_fx.sh`
  - `fx_rates` へのCSVインポート（ヘッダー1行を自動スキップ）
  - 使い方: `scripts/import_fx.sh data/fx_rates.csv [money_diary.db]`
- `scripts/export_snapshots.sh`
  - `snapshots` のヘッダー付きCSVエクスポート
  - 使い方: `scripts/export_snapshots.sh [data/snapshots.csv] [money_diary.db]`

## 背景/目的
MVP の手動運用（CSVベース）を支援し、手入力/検証の効率を高めるため。

## 使い方/確認方法
```bash
sqlite3 money_diary.db < schema.sql
./scripts/import_fx.sh data/fx_rates.csv
./scripts/export_snapshots.sh
```

## 関連Issue
Fixes #4
