### PR TITLE
chore: add quality target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tests/out/
 # OS cruft
 .DS_Store
 
+.venv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+SHELL := /bin/bash
+
+VENV ?= .venv
+PYTHON := $(VENV)/bin/python
+PIP := $(VENV)/bin/pip
+STREAMLIT := $(VENV)/bin/streamlit
+DB ?= money_diary.db
+
+.PHONY: help venv install db-init db-reset gui test quality clean
+
+help:
+	@echo "Available targets:"
+	@echo "  make venv        # Create Python virtualenv"
+	@echo "  make install     # Install requirements into virtualenv"
+	@echo "  make db-init     # Initialize SQLite schema (creates $(DB))"
+	@echo "  make db-reset    # Reset DB (drops and re-initializes $(DB))"
+	@echo "  make gui         # Launch Streamlit GUI"
+	@echo "  make test        # Run SQL regression tests"
+	@echo "  make quality     # Run quality checks (tests, linters)"
+	@echo "  make clean       # Remove virtualenv and DB"
+
+venv:
+	python3 -m venv $(VENV)
+
+install: venv requirements.txt
+	$(PIP) install --upgrade pip
+	$(PIP) install -r requirements.txt
+
+# Initialize DB once (non-destructive if file exists)
+db-init:
+	sqlite3 $(DB) < schema.sql
+
+# Warning: removes existing DB file
+db-reset:
+	rm -f $(DB)
+	sqlite3 $(DB) < schema.sql
+
+gui: install
+	$(STREAMLIT) run app/streamlit_app.py
+
+test:
+	./scripts/test.sh
+
+quality: test
+
+clean:
+	rm -rf $(VENV)
+	rm -f $(DB)

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ scripts/add_snapshot.sh
 
 ⸻
 
+🛠️ 開発補助（Makefile）
+- `make help`
+- `make venv && make install`
+- `make db-init`
+- `make test`
+- `make quality`
+- `make gui`
+
 **GUI 入力（ローカル）**
 - 事前準備
   - `python3 -m venv .venv && source .venv/bin/activate`


### PR DESCRIPTION
概要
- Makefileを追加し、品質・開発作業をワンコマンド化

変更点
- Makefile: venv生成、依存導入、DB初期化/リセット、GUI起動、quality(=test)などのターゲットを用意
- README: Makefileターゲット一覧を追記
- .gitignore: 仮想環境 `.venv` を除外

背景/目的
- コマンドを覚えずにMVP開発フロー（テスト/GUI/DB初期化）を実行できるようにするため

使い方/確認方法
```
make help
make quality
```

関連Issue
- なし

チェックリスト
- [x] テスト実行（make quality）
- [x] README更新
