### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: "direct"


### PR DESCRIPTION
概要
- GitHub Actions と pip 依存を週次でチェックする Dependabot を追加

変更点
- `.github/dependabot.yml` を新規作成し、`github-actions` と `pip` の2エコシステムを週次スケジュールで有効化

背景/目的
- CIやPython依存を継続的に最新化し、脆弱性や非互換を早期に検知するため

使い方/確認方法
- Dependabot が週1でPRを作成します（手動トリガー: GitHub UIから`Check for updates`）

関連Issue
- なし

チェックリスト
- [x] 設定ファイル追加
