### PR TITLE
chore: add CI quality workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install sqlite3
+        run: sudo apt-get update && sudo apt-get install -y sqlite3
+      - name: Run quality checks
+        run: make quality

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ scripts/add_snapshot.sh
 - `make quality`
 - `make gui`
 
+CI: push / PR ごとに GitHub Actions で `make quality` が実行されます。
+
 **GUI 入力（ローカル）**
 - 事前準備
   - `python3 -m venv .venv && source .venv/bin/activate`


### PR DESCRIPTION
概要
- GitHub Actions で `make quality` を自動実行するCIを追加

変更点
- `.github/workflows/ci.yml`: push / PR 時にUbuntuでSQLiteをインストールし `make quality` を実行
- `README.md`: CIが `make quality` を実行する旨を追記

背景/目的
- PRやmain更新で回帰テストを自動的に確認するため

使い方/確認方法
```
make quality
```

関連Issue
- なし

チェックリスト
- [x] テスト実行（make quality）
- [x] README更新
