### PR TITLE
feat: add charts tab to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,4 +151,5 @@ CI: push / PR ごとに GitHub Actions で `make quality` が実行されます�
 - 機能
   - Assets/Fx/Snapshots のフォーム入力（UPSERT）
   - 指定日付の `v_valuation` と `v_attribution` を一覧・CSVダウンロード
+  - Charts タブで `asset_prices` / `fx_rates` のラインチャート表示
   - DB が無ければ初回起動時に `schema.sql` を適用


### PR DESCRIPTION
概要
- Streamlit GUI にチャート表示タブを追加し、Asset Prices と FX Rates をラインチャートで可視化

変更点
- `app/streamlit_app.py`: asset_prices / fx_rates を取得するヘルパーを追加し、Chartsタブで期間指定・複数選択の折れ線グラフを表示
- `README.md`: GUI の機能一覧にチャート表示を追記

背景/目的
- 手入力後すぐに価格や為替推移を確認できる簡易ダッシュボードを提供するため

使い方/確認方法
```
streamlit run app/streamlit_app.py
# GUIの Charts タブで期間と対象を選択して折れ線グラフを表示
make quality
```

関連Issue
- #13

チェックリスト
- [x] テスト実行（make quality）
- [x] README更新
