### PR TITLE
feat: auto compute snapshot quantity

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ CI: push / PR ごとに GitHub Actions で `make quality` が実行されます�
   - `streamlit run app/streamlit_app.py`
 - 機能
   - Assets/Fx/Snapshots のフォーム入力（UPSERT）
+  - Snapshots で「評価額 (JPY)」入力から数量自動算出（価格・為替が揃っている場合）
   - 指定日付の `v_valuation` と `v_attribution` を一覧・CSVダウンロード
   - Charts タブで `asset_prices` / `fx_rates` のラインチャート表示
   - DB が無ければ初回起動時に `schema.sql` を適用


### PR DESCRIPTION
概要
- Snapshotsタブで評価額（JPY）入力から数量を自動算出できるようにし、価格・為替が揃っていない場合のハンドリングを追加

変更点
- `app/streamlit_app.py`: assetメタ情報/価格/FX取得ヘルパーを追加し、Snapshotsフォームで評価額・価格・数量を一体的に扱えるよう改善
  - 自動プリセット、前回値読み込み時の円換算保持、FX不足警告などを追加
- `README.md`: GUI機能一覧に評価額から数量を算出できる旨を追記

背景/目的
- 手元のJPY評価額だけで差分入力を完結させ、為替変換をアプリ側で自動化するため

使い方/確認方法
```
streamlit run app/streamlit_app.py
# Snapshotsタブで評価額(JPY)を入力 → FX/価格が揃っていれば数量が自動計算
make quality
```

関連Issue
- #13

チェックリスト
- [x] テスト実行（make quality）
- [x] README更新
