### PR TITLE
docs: add ER diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,44 @@ Money Diary は、個人利用に特化した資産・収支トラッキング�
    ./scripts/test.sh
    ```
 
+## ER 図
+
+主要テーブルの関係は以下のとおりです（`docs/er.mermaid` と同期）。
+
+```mermaid
+%%{init: {'theme': 'neutral'}}%%
+erDiagram
+    assets {
+        TEXT ticker PK "銘柄コード"
+        TEXT ccy "通貨 (ISO 3-letter)"
+        TEXT name "名称 (任意)"
+    }
+    fx_rates {
+        TEXT date PK "日付"
+        TEXT pair PK "通貨ペア (例: USDJPY)"
+        REAL rate "終値レート"
+    }
+    snapshots {
+        TEXT date PK "日付"
+        TEXT ticker PK "銘柄"
+        REAL qty "数量"
+        REAL price_ccy "現地通貨価格"
+    }
+    cashflows {
+        INTEGER id PK "ID"
+        TEXT date "日付"
+        TEXT ticker "銘柄"
+        TEXT type "種類 (DIVIDEND 等)"
+        REAL amount_ccy "金額"
+        TEXT ccy "通貨"
+    }
+
+    assets ||--o{ snapshots : "PK→FK"
+    assets ||--o{ cashflows : "PK→FK"
+    fx_rates ||..o{ snapshots : "日付+通貨で参照"
+    fx_rates ||..o{ cashflows : "日付+通貨で換算"
+```
+
 ### 手動入力スクリプト
 - `scripts/add_asset.sh` : 銘柄の追加 / 更新
 - `scripts/add_fx_manual.sh` : 指定日の FX レートを手入力

--- a/docs/er.mermaid
+++ b/docs/er.mermaid
@@ -1,0 +1,30 @@
+erDiagram
+    assets {
+        TEXT ticker PK "銘柄コード"
+        TEXT ccy "通貨 (ISO 3-letter)"
+        TEXT name "名称 (任意)"
+    }
+    fx_rates {
+        TEXT date PK "日付"
+        TEXT pair PK "通貨ペア (例: USDJPY)"
+        REAL rate "終値レート"
+    }
+    snapshots {
+        TEXT date PK "日付"
+        TEXT ticker PK "銘柄"
+        REAL qty "数量"
+        REAL price_ccy "現地通貨価格"
+    }
+    cashflows {
+        INTEGER id PK "ID"
+        TEXT date "日付"
+        TEXT ticker "銘柄"
+        TEXT type "種類 (DIVIDEND 等)"
+        REAL amount_ccy "金額"
+        TEXT ccy "通貨"
+    }
+
+    assets ||--o{ snapshots : "PK→FK"
+    assets ||--o{ cashflows : "PK→FK"
+    fx_rates ||..o{ snapshots : "日付+通貨で参照"
+    fx_rates ||..o{ cashflows : "日付+通貨で換算"


### PR DESCRIPTION
概要
- DB の主要テーブル関係を示す ER 図を追加

変更点
- `docs/er.mermaid` を作成し、assets / fx_rates / snapshots / cashflows の関係と主な列を整理
- README に mermaid コードブロックを追加し、図をインライン表示（ファイルと同期）

背景/目的
- Issue #9 の受入基準として、主要テーブルの依存関係を一目で把握できるようにするため

使い方/確認方法
```
# README の ER 図セクションを確認
# Mermaid サポートのあるビューアで docs/er.mermaid を参照
make quality
```

関連Issue
- #9

チェックリスト
- [x] テスト実行（make quality）
