### PR TITLE
feat: add timeseries charts to views

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,9 @@ CI（GitHub Actions）では push / PR ごとに `make quality` が実行され�
 3. 主な機能
    - Assets / FX / Snapshots のフォーム入力（UPSERT）
    - Snapshots で「評価額 (JPY)」入力から数量を自動算出（価格・為替が揃っている場合）
-   - 指定日の `v_valuation` / `v_attribution` を表示し、CSV ダウンロード
-   - Charts タブで `asset_prices` / `fx_rates` の推移をラインチャート表示
+   - Views タブで `v_valuation` / `v_attribution` に加え、ポートフォリオ合計・通貨別エクスポージャ・ウェイト付き評価額を表示（CSVダウンロード可）
+   - Views タブで直近○日分のポートフォリオ合計と通貨別エクスポージャを折れ線グラフ表示
+   - Charts タブで `asset_prices` / `fx_rates` の任意期間をラインチャート表示
    - DB が存在しない場合は起動時に `schema.sql` を自動適用
 
 ---


### PR DESCRIPTION
概要
- Viewsタブでポートフォリオ合計と通貨別エクスポージャの推移を自動グラフ化しました。

変更点
- `app/streamlit_app.py`: 新ビューの履歴取得ヘルパーを追加し、Viewsタブに折れ線グラフを表示（履歴日数スライダー付き）
- `README.md`: Viewsタブでの機能拡張を追記

背景/目的
- 入力データから時系列の推移を直感的に確認できるようにし、Snapshots→ビュー→グラフまでUIで完結させるため

使い方/確認方法
```
make quality
streamlit run app/streamlit_app.py
# Viewsタブで履歴表示（日数）スライダーを調整し、折れ線グラフが更新されることを確認
```

関連Issue
- #9

チェックリスト
- [x] テスト実行（make quality）
