### PR TITLE
feat: show all snapshots in table

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -470,12 +470,11 @@ def main():
                             )
                             st.rerun()
 
-        st.caption(f"{sel_date_str} のSnapshots")
+        st.caption("登録済み Snapshots 一覧")
         st.dataframe(
             q_all(
                 conn,
-                "SELECT date, ticker, qty, price_ccy FROM snapshots WHERE date = ? ORDER BY ticker",
-                (sel_date_str,),
+                "SELECT date, ticker, qty, price_ccy FROM snapshots ORDER BY date DESC, ticker",
             )
         )
 


### PR DESCRIPTION
概要
- Snapshotsタブの一覧を指定日フィルタではなく全件表示に変更しました。

変更点
- `app/streamlit_app.py`: フォーム下のテーブルを `snapshots` 全件（`ORDER BY date DESC, ticker`）に差し替え

背景/目的
- 指定日以外の入力履歴もまとめて確認したいという要望に対応

使い方/確認方法
```
make quality
streamlit run app/streamlit_app.py
# Snapshotsタブ最下部のテーブルに全スナップショットが表示されることを確認
```

関連Issue
- なし

チェックリスト
- [x] テスト実行（make quality）
