### PR TITLE
fix: detect views for schema refresh

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -92,7 +92,7 @@ def q_all(conn: sqlite3.Connection, sql: str, params: tuple = ()):
 def table_exists(conn: sqlite3.Connection, table: str) -> bool:
     cur = conn.cursor()
     cur.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        "SELECT name FROM sqlite_master WHERE type IN ('table', 'view') AND name=?",
         (table,),
     )
     return cur.fetchone() is not None


### PR DESCRIPTION
概要
- Viewsタブで「データが必要です」と表示される問題を修正

変更点
- `table_exists` をテーブルだけでなくビューも検知するよう変更し、既存DBでも `v_portfolio_total` 等を認識して履歴グラフを描画可能に

背景/目的
- 既存DBに新しいビューが存在するのに関数が検知できず、グラフ表示がスキップされていたため

使い方/確認方法
```
make quality
streamlit run app/streamlit_app.py
# Viewsタブで時系列グラフが正しく表示されることを確認
```

関連Issue
- なし

チェックリスト
- [x] テスト実行（make quality）
