### PR TITLE
feat: add OpenAI summary option

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,15 @@ CI（GitHub Actions）では push / PR ごとに `make quality` が実行され�
    - Charts タブで `asset_prices` / `fx_rates` の任意期間をラインチャート表示
    - DB が存在しない場合は起動時に `schema.sql` を自動適用
 
+### OpenAI API による要約（任意）
+1. 環境変数 `OPENAI_API_KEY` を設定（例: `.env` に追記して起動前に読み込む）
+2. `pip install -r requirements.txt` で `openai` パッケージを導入
+3. Views タブの「AI要約 (OpenAI)」を開き、
+   - 「選択日の要因を要約」: 現在表示中の日付の価格/為替/フローを要約
+   - 「全履歴を要約」: これまでの履歴から主要変動要因を俯瞰
+
+※ API 利用料が発生します。キーが未設定の場合は従来通りUIのみが表示されます。
+
 ---
 
 より詳しい貢献ルールは `AGENTS.md` を参照してください。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit>=1.31
 pandas>=2.0
+openai>=1.17


### PR DESCRIPTION
概要
- Viewsタブから OpenAI API を使って原因分解の要約を取得できるようにしました。

変更点
- `requirements.txt`: `openai` パッケージを追加
- `app/streamlit_app.py`
  - OpenAI 用ヘルパーとデータ収集ロジックを追加
  - Viewsタブに「AI要約 (OpenAI)」セクションを実装（選択日 / 全履歴の要約ボタン）
  - ポートフォリオ履歴グラフの期間指定をデータ範囲に基づくスライダーへ
- `README.md`: OPENAI_API_KEY 設定方法と要約機能の説明を追記

背景/目的
- 手作業で原因分解を読み解かなくても、AIが主要因を要約してくれるオプションを用意するため (#42)

使い方/確認方法
```
make quality
# optional: export OPENAI_API_KEY=sk-...
streamlit run app/streamlit_app.py
# Viewsタブ -> 「AI要約 (OpenAI)」で要約を取得
```

関連Issue
- #42

チェックリスト
- [x] テスト実行（make quality）
- [x] APIキー未設定時のガード表示
