### PR TITLE
chore: add ruff lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ VENV ?= .venv
 PYTHON := $(VENV)/bin/python
 PIP := $(VENV)/bin/pip
 STREAMLIT := $(VENV)/bin/streamlit
+RUFF := $(VENV)/bin/ruff
 DB ?= money_diary.db
 
-.PHONY: help venv install db-init db-reset gui test quality clean
+.PHONY: help venv install db-init db-reset gui lint test quality clean
 
 help:
 	@echo "Available targets:"
@@ -15,6 +16,7 @@ help:
 	@echo "  make db-init     # Initialize SQLite schema (creates $(DB))"
 	@echo "  make db-reset    # Reset DB (drops and re-initializes $(DB))"
 	@echo "  make gui         # Launch Streamlit GUI"
+	@echo "  make lint        # Run ruff lint"
 	@echo "  make test        # Run SQL regression tests"
 	@echo "  make quality     # Run quality checks (tests, linters)"
 	@echo "  make clean       # Remove virtualenv and DB"
@@ -38,10 +40,14 @@ db-reset:
 gui: install
 	$(STREAMLIT) run app/streamlit_app.py
 
+lint: install
+	$(RUFF) check app
+	$(RUFF) check scripts
+
 test:
 	./scripts/test.sh
 
-quality: test
+quality: lint test
 
 clean:
 	rm -rf $(VENV)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ erDiagram
 make help
 make venv && make install
 make db-init
+make lint
 make test
 make quality
 make gui

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -501,7 +501,6 @@ def main():
             with info_cols[1]:
                 st.metric("価格 (price_ccy)", f"{price_auto:.4f}" if price_auto else "-")
             with info_cols[2]:
-                fx_label = f"{ccy}JPY" if ccy and ccy != "JPY" else "JPY"
                 st.metric("FXレート", f"{fx_auto:.4f}" if fx_auto else ("1" if ccy == "JPY" else "-"))
 
             colp1, colp2, colp3 = st.columns([1, 1, 2])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit>=1.31
 pandas>=2.0
+ruff>=0.5
 openai>=1.17

--- a/scripts/fetch_fx.py
+++ b/scripts/fetch_fx.py
@@ -9,7 +9,7 @@ import time
 import urllib.error
 import urllib.request
 from collections import defaultdict
-from typing import Dict, Iterable
+from typing import Dict
 
 BASE_URL = "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}?interval=1d&period1={start}&period2={end}"
 


### PR DESCRIPTION
概要
- Makefile に ruff lint を組み込み、品質チェックで lint + test を実行できるようにしました。

変更点
- `Makefile`: `make lint` を追加し、`make quality` が `lint` と `test` を連続実行
- `requirements.txt`: `ruff>=0.5` を追加
- `README.md`: Makefile 手順に `make lint` を追記
- `scripts/fetch_fx.py` / `app/streamlit_app.py`: lint 違反だった未使用変数・import を削除

背景/目的
- Issue #42 の実装に伴い lint ターゲットが抜けてしまったため復元

使い方/確認方法
```
make lint
make quality
```

関連Issue
- なし

チェックリスト
- [x] テスト実行（make lint / make quality）
