### PR TITLE
chore: cache Python deps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,13 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-
-      - name: Install sqlite3
-        run: sudo apt-get update && sudo apt-get install -y sqlite3
+      - name: Ensure sqlite3
+        run: |
+          if ! command -v sqlite3 >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y sqlite3
+          else
+            sqlite3 --version
+          fi
       - name: Run quality checks
         run: make quality

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Cache virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            venv-${{ runner.os }}-
       - name: Install sqlite3
         run: sudo apt-get update && sudo apt-get install -y sqlite3
       - name: Run quality checks


### PR DESCRIPTION
概要
- CI で Python 依存のインストールをキャッシュし、`make quality` の実行を高速化しました。

変更点
- `.github/workflows/ci.yml`
  - `actions/setup-python@v5` を使用し、`cache: 'pip'` と `cache-dependency-path: requirements.txt` を設定
  - `.venv` ディレクトリを `actions/cache@v4` でキャッシュ（キーは requirements.txt のハッシュ）

背景/目的
- CI 時の `pip install` や virtualenv 構築の繰り返しを避けるため

使い方/確認方法
- GitHub Actions の `CI` ワークフローが `make quality` を実行し、以後の実行でキャッシュがヒットすることを確認

関連Issue
- なし

チェックリスト
- [x] lint / test（make lint, make quality）
