### PR TITLE
chore: switch dependency management to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,6 @@ jobs:
       - name: Run quality checks
         run: |
           uv python install 3.12
+          uv venv --python 3.12
           uv sync --frozen
           make quality

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ help:
 
 install: pyproject.toml
 	$(UV) python install 3.12
+	$(UV) venv --python 3.12
 	$(UV) sync
 
 # Initialize DB once (non-destructive if file exists)

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ CI（GitHub Actions）では push / PR ごとに `make quality` が実行され�
    ```bash
    # uv が未インストールの場合: https://docs.astral.sh/uv/getting-started/ を参照
    uv python install 3.12
+   uv venv --python 3.12
    uv sync
    # もしくは make install（uv 実行をラップ）
    make install


### PR DESCRIPTION
概要
- 依存管理と実行環境を uv ベースに統一しました。

変更点
- `pyproject.toml` / `uv.lock` を追加し、`requirements.txt` を廃止
- `Makefile`: `uv venv` + `uv sync` を利用し、`make lint/test/quality/gui` を `uv run` 経由に変更
- `.github/workflows/ci.yml`: `astral-sh/setup-uv` を導入し、CI でも uv で依存同期
- `README.md`: セットアップ手順を uv 中心に更新

背景/目的
- #42 の実装に伴い高速な依存導入とツールチェーン統一を図るため

使い方/確認方法
```
make install
make lint
make quality
make gui
```

関連Issue
- #42

チェックリスト
- [x] make lint
- [x] make quality
