### PR TITLE
feat: load .env via python-dotenv

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -6,15 +6,20 @@ from pathlib import Path
 
 import pandas as pd
 import streamlit as st
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).resolve().parent.parent
+DB_DEFAULT = ROOT / "money_diary.db"
+SCHEMA_PATH = ROOT / "schema.sql"
+
+env_path = ROOT / ".env"
+load_dotenv(env_path)
+
 
 try:
     from openai import OpenAI
 except Exception:  # pragma: no cover
     OpenAI = None
-
-ROOT = Path(__file__).resolve().parent.parent
-DB_DEFAULT = ROOT / "money_diary.db"
-SCHEMA_PATH = ROOT / "schema.sql"
 
 
 def get_conn(db_path: Path) -> sqlite3.Connection:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,5 @@ dependencies = [
   "pandas>=2.0",
   "ruff>=0.5",
   "openai>=1.17",
+  "python-dotenv>=1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -351,6 +351,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "openai" },
     { name = "pandas" },
+    { name = "python-dotenv" },
     { name = "ruff" },
     { name = "streamlit" },
 ]
@@ -359,6 +360,7 @@ dependencies = [
 requires-dist = [
     { name = "openai", specifier = ">=1.17" },
     { name = "pandas", specifier = ">=2.0" },
+    { name = "python-dotenv", specifier = ">=1.0" },
     { name = "ruff", specifier = ">=0.5" },
     { name = "streamlit", specifier = ">=1.31" },
 ]
@@ -686,6 +688,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要
- python-dotenv を導入し、Streamlit 起動時に .env を自動ロードできるようにしました。

## 変更点
- 依存関係に python-dotenv を追加。
- Streamlit アプリで load_dotenv を呼び出すよう更新。

## 背景/目的
-  の  が読み込まれず AI要約カードに警告が出ていたため。

## 使い方/確認方法
```
uv run streamlit run app/streamlit_app.py
```
- AI要約カードの警告が消えていることを確認。

## 関連Issue
- なし

## チェックリスト
- [x] make quality
